### PR TITLE
Use simpler code in unreachable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,4 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-void = "0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,6 @@
 
 extern crate void;
 
-use std::mem;
-
 /// Hint to the optimizer that any code path which calls this function is
 /// statically unreachable and can be removed.
 ///
@@ -19,8 +17,9 @@ use std::mem;
 /// suitable.
 #[inline]
 pub unsafe fn unreachable() -> ! {
-    let x: &void::Void = mem::transmute(1usize);
-    void::unreachable(*x)
+    match *(1 as *const void::Void) {
+        /* unreachable */
+    }
 }
 
 /// An extension trait for `Option<T>` providing unchecked unwrapping methods.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,6 @@
 //! extension traits for `Option` and `Result`.
 //!
 
-extern crate void;
-
 /// Hint to the optimizer that any code path which calls this function is
 /// statically unreachable and can be removed.
 ///
@@ -17,7 +15,9 @@ extern crate void;
 /// suitable.
 #[inline]
 pub unsafe fn unreachable() -> ! {
-    match *(1 as *const void::Void) {
+    enum Void { }
+
+    match *(1 as *const Void) {
         /* unreachable */
     }
 }


### PR DESCRIPTION
This was recommended by aatch in a discussion on the rfcs repo.

I would prefer to remove the link to the void crate. The void crate makes sense to have a common definiton of a Void type, but here we're not using it in a user visible interface, and any voidish enum will do. It's simpler to just define it where it is needed.