### PR TITLE
Unwrap ref

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "unreachable"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Jonathan Reem <jonathan.reem@gmail.com>"]
 repository = "https://github.com/reem/rust-unreachable.git"
 description = "An unreachable code optimization hint in stable rust."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,12 @@ pub trait UncheckedOptionExt<T> {
     /// Get the value out of this Option without checking for None.
     unsafe fn unchecked_unwrap(self) -> T;
 
+    /// Get a reference to the value in this Option without checking for None.
+    unsafe fn unchecked_unwrap_as_ref(&self) -> &T;
+
+    /// Get a mutable reference to the value in this Option without checking for None.
+    unsafe fn unchecked_unwrap_as_mut(&mut self) -> &mut T;
+
     /// Assert that this Option is a None to the optimizer.
     unsafe fn unchecked_unwrap_none(self);
 }
@@ -39,14 +45,40 @@ pub trait UncheckedResultExt<T, E> {
     /// Get the value out of this Result without checking for Err.
     unsafe fn unchecked_unwrap_ok(self) -> T;
 
+    /// Get a reference to the value in this Result without checking for Err.
+    unsafe fn unchecked_unwrap_ok_as_ref(&self) -> &T;
+
+    /// Get a mutable reference to the value in this Result without checking for Err.
+    unsafe fn unchecked_unwrap_ok_as_mut(&mut self) -> &mut T;
+
     /// Get the error out of this Result without checking for Ok.
     unsafe fn unchecked_unwrap_err(self) -> E;
+
+    /// Get a reference to the value in this Result without checking for Ok.
+    unsafe fn unchecked_unwrap_err_as_ref(&self) -> &E;
+
+    /// Get a mutable reference to the value in this Result without checking for Ok.
+    unsafe fn unchecked_unwrap_err_as_mut(&mut self) -> &mut E;
 }
 
 impl<T> UncheckedOptionExt<T> for Option<T> {
     unsafe fn unchecked_unwrap(self) -> T {
         match self {
             Some(x) => x,
+            None => unreachable()
+        }
+    }
+
+    unsafe fn unchecked_unwrap_as_ref(&self) -> &T {
+        match *self {
+            Some(ref x) => x,
+            None => unreachable()
+        }
+    }
+
+    unsafe fn unchecked_unwrap_as_mut(&mut self) -> &mut T {
+        match *self {
+            Some(ref mut x) => x,
             None => unreachable()
         }
     }
@@ -67,10 +99,38 @@ impl<T, E> UncheckedResultExt<T, E> for Result<T, E> {
         }
     }
 
+    unsafe fn unchecked_unwrap_ok_as_ref(&self) -> &T {
+        match *self {
+            Ok(ref x) => x,
+            Err(_) => unreachable()
+        }
+    }
+
+    unsafe fn unchecked_unwrap_ok_as_mut(&mut self) -> &mut T {
+        match *self {
+            Ok(ref mut x) => x,
+            Err(_) => unreachable()
+        }
+    }
+
     unsafe fn unchecked_unwrap_err(self) -> E {
         match self {
             Ok(_) => unreachable(),
             Err(e) => e
+        }
+    }
+
+    unsafe fn unchecked_unwrap_err_as_ref(&self) -> &E {
+        match *self {
+            Ok(_) => unreachable(),
+            Err(ref e) => e
+        }
+    }
+
+    unsafe fn unchecked_unwrap_err_as_mut(&mut self) -> &mut E {
+        match *self {
+            Ok(_) => unreachable(),
+            Err(ref mut e) => e
         }
     }
 }


### PR DESCRIPTION
This PR adds methods for unsafe unwrapping references out of Option and Result. Although `Option::as_ref()` and `Option::as_mut()` might suffice and it is probable that compiler would optimize it away, these method provide more convenience.