### PR TITLE
Remove dependency on void crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,3 @@ repository = "https://github.com/reem/rust-unreachable.git"
 description = "An unreachable code optimization hint in stable rust."
 readme = "README.md"
 license = "MIT / Apache-2.0"
-
-[dependencies.void]
-version = "1"
-default-features = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,9 @@
 
 #![no_std]
 
-extern crate void;
-
 use core::mem;
+
+enum Void {}
 
 /// Hint to the optimizer that any code path which calls this function is
 /// statically unreachable and can be removed.
@@ -21,8 +21,8 @@ use core::mem;
 /// suitable.
 #[inline]
 pub unsafe fn unreachable() -> ! {
-    let x: &void::Void = mem::transmute(1usize);
-    void::unreachable(*x)
+    let x: &Void = mem::transmute(1usize);
+    match *x {}
 }
 
 /// An extension trait for `Option<T>` providing unchecked unwrapping methods.


### PR DESCRIPTION
Just writing out the functionality that the void crate provides actually
takes less lines than taking it as a dependency. The void crate provides
more, but it is not used by this crate, so it is only wasteful to
compile.

Version 1.0.2 of the void crate takes 2.4 KiB on my disk. That is not a
lot in terms of disk space, nor in terms of bandwith -- for me. But now
that this crate is a transitive dependency of a popular crate, it is
being downloaded more than 3000 times per day according to crates.io,
wasting 0.2 GiB per month. Still not a lot, but not necessary either.
Furthermore, the extra dependency adds an extra network roundtrip to
a clean build with no cached dependencies (such as many CI builds).
On a bad connection that can make a noticeable difference.

Finally, one of the advantages of relying on an external crate -- being
able to independently and centrally fix bugs -- does not apply so much
here. Those few lines of code are more likely in the "obviously no bugs"
category than in the "no obvious bugs" category.