### PR TITLE
cargo: require at least void 1.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ readme = "README.md"
 license = "MIT / Apache-2.0"
 
 [dependencies.void]
-version = "1"
+version = "1.0.1"
 default-features = false


### PR DESCRIPTION
`void` 1.0.0 uses `extern crate core;` which is not valid. Update to
allow `-Z minimal-versions` builds to work.